### PR TITLE
fix: avoid displaying {{street}} when providing an empty street name

### DIFF
--- a/scripts/script.yaml
+++ b/scripts/script.yaml
@@ -141,6 +141,19 @@
             - default: true                   # <---- for returning reporters, pass
 
         - switch:
+            arg: _location                    # _location is the concatenation of an optional street and the city
+            cases:
+            - undefined: true                 # <---- for new users, create _location
+              steps:
+              - do:
+                  cmd: combine_location
+                  variable: _location
+                  params:
+                    - record
+                    - "{{street}} {{city_town}}"
+            - default: true                   # <---- for returning users, we already have saved _location
+
+        - switch:
             arg: alias                         # alias is our user identifier (age+sex+street+city)
             cases:
             - undefined: true                            #<--- for new users, create alias
@@ -150,8 +163,8 @@
                   variable: alias
                   params:
                     - record
-                    - "בן {{age}} מ{{street}} {{city_town}}"
-                    - "בת {{age}} מ{{street}} {{city_town}}"
+                    - "בן {{age}} מ{{_location}}"
+                    - "בת {{age}} מ{{_location}}"
               - say: נהדר, בכדי לשמור על הפרטיות שלך, בדיווחים הבאים נקרא לך פשוט {{alias}}
             - default: true                 # <---- for returning users, we already have saved alias
 
@@ -172,7 +185,7 @@
             - match: true
             - default: true
               steps:
-              - say: "יש לנו כמה שאלות (שנשאל פעם אחת) לגבי הבית ב{{street}} {{city_town}} -"
+              - say: "יש לנו כמה שאלות (שנשאל פעם אחת) לגבי הבית ב{{_location}} -"
               - say: כמה מבוגרים מעל לגיל 18 גרים בבית?
               - switch:
                   arg: _is_adult

--- a/src/app/chat-page/chat-page.component.ts
+++ b/src/app/chat-page/chat-page.component.ts
@@ -432,6 +432,9 @@ export class ChatPageComponent implements OnInit, AfterViewInit {
             return this.fillIn(record, female_alias);
           }
         },
+        combine_location: (record, location_text) => {
+          return this.fillIn(record, location_text).trim();
+        },
         prepare_city_town_suggestions: () => {
           return citySuggestions[this.locale] || citySuggestions['en'];
         },


### PR DESCRIPTION
when an empty (none) street value is provided, the hatool variable replacement uses the name of the field, `street` in this case.

the fix relies on a new calculated variable `_location` which is the trimmed result of concatenating the optional street name and the city.